### PR TITLE
Updated Vagrant Repo References

### DIFF
--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure(2) do |config|
   # GlusterFS File Server 1
   disk_file_1 = File.join(VAGRANT_ROOT, 'gfs_brick_1.vdi')
   config.vm.define :file_server_1 do |fs_config|
-    fs_config.vm.box = "chef/centos-6.5"
+    fs_config.vm.box = "bento/centos-6.7"
     fs_config.vm.host_name = "file-server-1.test.dev"
 
     fs_config.ssh.forward_agent = true
@@ -46,7 +46,7 @@ Vagrant.configure(2) do |config|
   # GlusterFS File Server 2
   disk_file_2 = File.join(VAGRANT_ROOT, 'gfs_brick_2.vdi')
   config.vm.define :file_server_2 do |fs_config|
-    fs_config.vm.box = "chef/centos-6.5"
+    fs_config.vm.box = "bento/centos-6.7"
     fs_config.vm.host_name = "file-server-2.test.dev"
 
     fs_config.vm.provision :shell,
@@ -78,7 +78,7 @@ Vagrant.configure(2) do |config|
 
   # Admin Terminal VM
   config.vm.define :admin_terminal do |adterm_config|
-    adterm_config.vm.box = "chef/centos-6.5"
+    adterm_config.vm.box = "bento/centos-6.7"
     adterm_config.vm.host_name = "admin.test.dev"
 
     adterm_config.ssh.forward_agent = true
@@ -97,7 +97,7 @@ Vagrant.configure(2) do |config|
 
   # Kerberos Server VM - for testing purposes only
   config.vm.define :kerberos_server do |kerberos_config|
-    kerberos_config.vm.box = "chef/centos-6.5"
+    kerberos_config.vm.box = "bento/centos-6.7"
     kerberos_config.vm.host_name = "kdc.test.dev"
 
     kerberos_config.vm.provision :shell,
@@ -127,7 +127,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.define :proxy_server do |proxy_config|
-    proxy_config.vm.box = "chef/centos-6.5"
+    proxy_config.vm.box = "bento/centos-6.7"
     proxy_config.vm.host_name = "proxy.test.dev"
 
     proxy_config.vm.provision :shell,
@@ -161,7 +161,7 @@ Vagrant.configure(2) do |config|
 
   # Analytics Terminal
   config.vm.define :analytics_terminal do |analytics_config|
-    analytics_config.vm.box = "chef/centos-6.5"
+    analytics_config.vm.box = "bento/centos-6.7"
     analytics_config.vm.host_name = "analytics.test.dev"
 
     analytics_config.ssh.forward_agent = true
@@ -185,7 +185,7 @@ Vagrant.configure(2) do |config|
 
   # Kibana Client Node
   config.vm.define "elk" do |elk_config|
-    elk_config.vm.box = "chef/centos-6.5"
+    elk_config.vm.box = "bento/centos-6.7"
     elk_config.vm.host_name = "elk.test.dev"
     elk_config.ssh.forward_agent = true
 
@@ -204,7 +204,7 @@ Vagrant.configure(2) do |config|
   # Elastic Search Cluster
   (1..3).each do |i|
     config.vm.define "es#{i}" do |es_config|
-      es_config.vm.box = "chef/centos-6.5"
+      es_config.vm.box = "bento/centos-6.7"
       es_config.vm.host_name = "es#{i}.test.dev"
       es_config.ssh.forward_agent = true
 
@@ -223,7 +223,7 @@ Vagrant.configure(2) do |config|
 
   # App server
   config.vm.define :app_server do |app_config|
-    app_config.vm.box = "chef/centos-6.5"
+    app_config.vm.box = "bento/centos-6.7"
     app_config.vm.host_name = "app.test.dev"
 
     app_config.ssh.forward_agent = true
@@ -248,7 +248,7 @@ Vagrant.configure(2) do |config|
 
   # Research ancillary server
   config.vm.define :research_ancillary_services do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "research-ancillary.test.dev"
 
     server.ssh.forward_agent = true
@@ -263,7 +263,7 @@ Vagrant.configure(2) do |config|
 
   # Research EOD server
   config.vm.define :research_eod do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "research-eod.test.dev"
 
     server.ssh.forward_agent = true
@@ -279,7 +279,7 @@ Vagrant.configure(2) do |config|
 
   # Research gauss server
   config.vm.define :research_gauss do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "research-gauss.test.dev"
 
     server.ssh.forward_agent = true
@@ -295,7 +295,7 @@ Vagrant.configure(2) do |config|
 
   # Research stata server
   config.vm.define :research_stata do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "research-stata.test.dev"
 
     server.ssh.forward_agent = true
@@ -311,7 +311,7 @@ Vagrant.configure(2) do |config|
 
   # Research R/Python server
   config.vm.define :research_python do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "research-python.test.dev"
 
     server.ssh.forward_agent = true
@@ -327,7 +327,7 @@ Vagrant.configure(2) do |config|
 
   # Research Matlab server
   config.vm.define :research_matlab do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "research-matlab.test.dev"
 
     server.ssh.forward_agent = true
@@ -343,7 +343,7 @@ Vagrant.configure(2) do |config|
 
   # Research SPSS server
   config.vm.define :research_spss do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "research-spss.test.dev"
 
     server.ssh.forward_agent = true
@@ -359,7 +359,7 @@ Vagrant.configure(2) do |config|
 
   # Research SAS server
   config.vm.define :research_sas do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "research-sas.test.dev"
 
     server.ssh.forward_agent = true
@@ -377,7 +377,7 @@ Vagrant.configure(2) do |config|
   ### PIPELINES COMPONENT ###
   #######################
   config.vm.define :ci_server do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "ci-server.test.dev"
 
     server.ssh.forward_agent = true
@@ -392,7 +392,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.define :ci_agent_1 do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "ci-agent-1.test.dev"
 
     server.ssh.forward_agent = true
@@ -407,7 +407,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.define :ci_terminal_1 do |server|
-    server.vm.box = "chef/centos-6.5"
+    server.vm.box = "bento/centos-6.7"
     server.vm.host_name = "ci-terminal-1.test.dev"
 
     server.ssh.forward_agent = true


### PR DESCRIPTION
Due to removal of Chef Vagrant repos' centos 6.5 image, chef/centos-6.5 has been replaced with bento/centos-6.7.
