### PR TITLE
Added better logic to support UX for standing up db_server

### DIFF
--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -1,9 +1,16 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'fileutils'
 
 Vagrant.configure(2) do |config|
 
   ### COMMON VARIABLES
+
+  # First make sure that an .vault_password file exists, and if it doesn't
+  # then create an empty file
+  if not File.file?('.vault_password')
+    FileUtils.touch('.vault_password')
+  end
 
   # Constant var holding the root directory where this vagrantfile is being run
   VAGRANT_ROOT = File.dirname(File.expand_path(__FILE__))
@@ -31,7 +38,7 @@ Vagrant.configure(2) do |config|
 
 #       v.customize ['storagectl', :id, '--name', 'SATA Controller', '--add', 'sata', '--portcount', 1]
 #       TODO: Detect if SATA controller exists, and only add it if needed
-       
+
         v.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', disk_file_1]
       end
     end
@@ -447,12 +454,21 @@ Vagrant.configure(2) do |config|
     end
 
     server.vm.provision "ansible" do |ansible|
-      ansible.playbook = "deploy_db_server.yml"
-      ansible.inventory_path = "vagrant_hosts"
-
       if ENV['DB_SERVER_EXTRA_VARS']
         ansible.extra_vars = ENV['DB_SERVER_EXTRA_VARS']
+      else
+        print "You must set the DB_SERVER_EXTRA_VARS environment variable to the name of a local YAML file that contains pp_web_username (email addresses only) and pp_web_password.\n"
+        print "Example:\n"
+        print "$ export DB_SERVER_EXTRA_VARS=local_settings.yml\n"
+        print "$ cat local_settings.yml\n"
+        print "---\n"
+        print "pp_web_username: myusername@example.com\n"
+        print "pp_web_password: mypassword\n"
+        exit
       end
+
+      ansible.playbook = "deploy_db_server.yml"
+      ansible.inventory_path = "vagrant_hosts"
 
       ansible.tags = ansible_tags
     end

--- a/deploy/roles/jdk/defaults/main.yml
+++ b/deploy/roles/jdk/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 jdk_packages:
-  - java-1.8.0-openjdk
-  - java-1.8.0-openjdk-devel
+  - java-1.8.0-openjdk-1:1.8.0.77-0.b03.el6_7.x86_64
+  - java-1.8.0-openjdk-devel-1:1.8.0.77-0.b03.el6_7.x86_64
   - libselinux-python
 
 java_deploy_options: []

--- a/deploy/roles/postgresql-server/defaults/main.yml
+++ b/deploy/roles/postgresql-server/defaults/main.yml
@@ -15,6 +15,7 @@ pp_extract_only: no
 pp_installer_language: en
 
 # EnterpriseDB Web Account (register here: http://www.enterprisedb.com/user-login-registration)
+# Put these settings in your DB_SERVER_EXTRA_VARS file with your username and password.
 pp_web_username: webusername_goes_here
 pp_web_password: webpassword_goes_here
 

--- a/deploy/roles/postgresql-server/tasks/main.yml
+++ b/deploy/roles/postgresql-server/tasks/main.yml
@@ -14,11 +14,12 @@
 
 - name: Download and extract PostgresPlus Advanced Server installer
   unarchive:
-    src: "{{ pp_bin_path }}/ppasmeta-{{ pp_installer_version }}-linux-x64.tar.gz"
+    src: "http://get.enterprisedb.com/ga/ppasmeta-9.4.1.3-linux-x64.tar.gz"
     dest: "{{ pp_temp_dir }}/"
     owner: "{{ ansible_ssh_user }}"
     group: "{{ ansible_ssh_user }}"
     mode: 0700
+    copy: no
 
 - name: Create configuration file
   template:

--- a/deploy/roles/postgresql-server/tasks/main.yml
+++ b/deploy/roles/postgresql-server/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Download and extract PostgresPlus Advanced Server installer
   unarchive:
-    src: "http://get.enterprisedb.com/ga/ppasmeta-9.4.1.3-linux-x64.tar.gz"
+    src: "http://get.enterprisedb.com/ga/ppasmeta-{{ pp_installer_version }}-linux-x64.tar.gz"
     dest: "{{ pp_temp_dir }}/"
     owner: "{{ ansible_ssh_user }}"
     group: "{{ ansible_ssh_user }}"


### PR DESCRIPTION
@frank0651 - These changes automatically create a .vault_password file (empty), and prompt the user to set the DB_SERVER_EXTRA_VARS environment variable when vagrant up db_server is run.  The PPAS installer is now downloaded directly from EnterpriseDB instead of the requiring the file to be present.
