### PR TITLE
WIP: Mesos changes to implement persistent volumes

### DIFF
--- a/deploy/config_analytics_terminal.yml
+++ b/deploy/config_analytics_terminal.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: analytics_terminal
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - r-studio-server-config
     - r-shiny-config

--- a/deploy/config_elasticsearch.yml
+++ b/deploy/config_elasticsearch.yml
@@ -1,18 +1,21 @@
 ---
 - hosts: elasticsearch
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - elasticsearch-config
 
 - hosts: elk
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - elasticsearch-config
     - logstash-config
     - kibana-config
 
 - hosts: elk
-  sudo: yes
+  become: yes
+  become_method: sudo
   handlers:
     - include: roles/shared/handlers/main.yml
   tasks:

--- a/deploy/config_file_server.yml
+++ b/deploy/config_file_server.yml
@@ -4,7 +4,8 @@
 # without extensive modification.
 ---
 - hosts: file_server_2
-  sudo: yes
+  become: yes
+  become_method: sudo
 
   tasks:
     - name: Probe for other file server

--- a/deploy/config_nginx_proxy_server.yml
+++ b/deploy/config_nginx_proxy_server.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: nginx_server
-  sudo: yes
+  become: yes
+  become_method: sudo
   handlers:
     - include: roles/apache/handlers/main.yml
   tasks:

--- a/deploy/deploy_admin_terminal.yml
+++ b/deploy/deploy_admin_terminal.yml
@@ -1,7 +1,8 @@
 # deploy_admin_terminal.yml
 ---
 - hosts: admin_terminal
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - {role: puppet_disable, when: "disable_puppet"}
     - {role: iptables, when: "iptables_config"}

--- a/deploy/deploy_analytics_terminal.yml
+++ b/deploy/deploy_analytics_terminal.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: analytics_terminal
   become: yes
+  become_method: sudo
   roles:
     - {role: puppet_disable, when: "disable_puppet"}
     - {role: epel, when: "use_epel and not 'production' in group_names"}
@@ -27,6 +28,7 @@
 # Install development packages
 - hosts: analytics_terminal
   become: yes
+  become_method: sudo
   tasks:
     - name: Install packages development packages
       yum:
@@ -75,6 +77,7 @@
 
 - hosts: analytics_terminal
   become: yes
+  become_method: sudo
   roles:
     - eod
     - r
@@ -89,6 +92,7 @@
 
 - hosts: analytics_terminal
   become: yes
+  become_method: sudo
   tasks:
     - name: Open port range for app prototyping
       command: "iptables -I {{ iptables_chain }} 3 -m state --state NEW -p tcp --dport 8000:8100 -s {{ hostvars[item]['ansible_ssh_host'] }} -j ACCEPT"

--- a/deploy/deploy_app_server.yml
+++ b/deploy/deploy_app_server.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: app_server
   become: yes
+  become_method: sudo
   roles:
     - {role: puppet_disable, when: "disable_puppet"}
     - {role: iptables, when: "iptables_config"}
@@ -24,6 +25,7 @@
 # Install development packages
 - hosts: app_server
   become: yes
+  become_method: sudo
   tasks:
     - name: Install development packages
       yum:
@@ -72,6 +74,7 @@
 
 - hosts: app_server
   become: yes
+  become_method: sudo
   roles:
     - jdk
     - revolution-r
@@ -82,6 +85,7 @@
 
 - hosts: app_server
   become: yes
+  become_method: sudo
   tasks:
     - name: Open port range for app services
       command: "iptables -I {{ iptables_chain }} 3 -m state --state NEW -p tcp --dport 30000:31000 -s {{ hostvars[item]['ansible_ssh_host'] }} -j ACCEPT"

--- a/deploy/deploy_db_server.yml
+++ b/deploy/deploy_db_server.yml
@@ -1,7 +1,8 @@
 # deploy_db_server.yml
 ---
 - hosts: db_server
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - {role: iptables, when: "iptables_config"}
 #    - {role: common, when: "install_glusterfs"}

--- a/deploy/deploy_db_terminal.yml
+++ b/deploy/deploy_db_terminal.yml
@@ -1,7 +1,8 @@
 # deploy_admin_terminal.yml
 ---
 - hosts: db_terminal
-  sudo: yes
+  become: yes
+  become_method: sudo
 
   roles:
     - umask

--- a/deploy/deploy_elastic_search.yml
+++ b/deploy/deploy_elastic_search.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: elasticsearch
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - common
     - {role: puppet_disable, when: "disable_puppet"}

--- a/deploy/deploy_elk.yml
+++ b/deploy/deploy_elk.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: elk
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - common
     - {role: puppet_disable, when: "disable_puppet"}
@@ -10,7 +11,8 @@
     - elasticsearch
 
 - hosts: elk
-  sudo: yes
+  become: yes
+  become_method: sudo
   handlers:
     - include: roles/shared/handlers/main.yml
   pre_tasks:

--- a/deploy/deploy_kerberos_server.yml
+++ b/deploy/deploy_kerberos_server.yml
@@ -1,7 +1,8 @@
 # kerberos_server.yml - Mock server to test Kerberos authentication
 ---
 - hosts: all
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - {role: puppet_disable, when: "disable_puppet"}
     - iptables

--- a/deploy/deploy_mesos_agent.yml
+++ b/deploy/deploy_mesos_agent.yml
@@ -3,6 +3,7 @@
 ---
 - hosts: mesos_agent
   become: yes
+  become_method: sudo
   roles:
     - common
     - {role: iptables, when: "iptables_config"}
@@ -17,6 +18,7 @@
 
 - hosts: mesos_agent
   become: yes
+  become_method: sudo
   tasks:
     - name: Activate Julia repo
       get_url:
@@ -36,6 +38,7 @@
 
 - hosts: mesos_agent
   become: yes
+  become_method: sudo
   roles:
     - {role: python, when: "custom_repo"}
     - {role: python-build, when: "not custom_repo"}
@@ -51,6 +54,7 @@
 
 - hosts: mesos_agent
   become: yes
+  become_method: sudo
   tasks:
     - name: Turn off Shiny Server
       service:

--- a/deploy/deploy_mesos_master.yml
+++ b/deploy/deploy_mesos_master.yml
@@ -1,7 +1,8 @@
 # deploy_mesos_master.yml
 ---
 - hosts: mesos_master
-  sudo: yes
+  become: yes
+  become_method: sudo
   serial: 1
   max_fail_percentage: 30
   roles:

--- a/deploy/deploy_nginx_proxy_server.yml
+++ b/deploy/deploy_nginx_proxy_server.yml
@@ -2,7 +2,8 @@
 # that allows external access to the data enclave.
 ---
 - hosts: nginx_server
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - {role: puppet_disable, when: "disable_puppet"}
     - {role: iptables, when: "iptables_config"}

--- a/deploy/deploy_proxy_server.yml
+++ b/deploy/deploy_proxy_server.yml
@@ -2,7 +2,8 @@
 # that allows external access to the data enclave.
 ---
 - hosts: proxy_server
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - {role: puppet_disable, when: "disable_puppet"}
     - {role: iptables, when: "iptables_config"}

--- a/deploy/deploy_research_environment.yml
+++ b/deploy/deploy_research_environment.yml
@@ -1,12 +1,14 @@
 ---
 - hosts: research_environment
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - {role: iptables, when: "iptables_config"}
     - {role: common, when: "install_glusterfs"}
 
 - hosts: research_ancillary_services
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - devtools
     - emacs
@@ -25,25 +27,29 @@
       when: custom_repo
 
 - hosts: research_eod
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - eod
 
 - hosts: research_gauss
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - gauss
     - odbc
     - gocd
 
 - hosts: research_stata
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - stata
     - odbc
 
 - hosts: research_python
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     - devtools
     - {role: python, when: "custom_repo"}
@@ -82,21 +88,24 @@
       with_items: python3_packages
 
 - hosts: research_sas
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     # - sas
     - odbc
     - gocd
 
 - hosts: research_spss
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     # - spss
     - odbc
     - gocd
 
 - hosts: research_matlab
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
     # - matlab
     - odbc

--- a/deploy/roles/gocd/defaults/main.yaml
+++ b/deploy/roles/gocd/defaults/main.yaml
@@ -4,7 +4,7 @@ go_server_port: 8153
 gocd_agent_package_url: https://download.go.cd/binaries/16.9.0-4001/rpm/go-agent-16.9.0-4001.noarch.rpm
 gocd_agent_package_name: go-agent-16.9.0-4001.noarch.rpm
 gocd_agent_package_path: /tmp
-gocd_agent_checksum: "b010587fa78ffa8fee31a53af7d58c2c3fdb7a01"
+gocd_agent_checksum: "7ab77bb44193868f98bec664e6110bb2ac801487"
 gocd_agent_work_dir: /var/lib/go-agent
 gocd_agent_mem: "128m"
 gocd_agent_max_mem: "256m"

--- a/deploy/roles/gocd/defaults/main.yaml
+++ b/deploy/roles/gocd/defaults/main.yaml
@@ -1,8 +1,8 @@
 ---
 go_server_address: 10.0.1.26
 go_server_port: 8153
-gocd_agent_package_url: https://download.go.cd/binaries/16.3.0-3183/rpm/go-agent-16.3.0-3183.noarch.rpm
-gocd_agent_package_name: go-agent-16.3.0-3183.noarch.rpm
+gocd_agent_package_url: https://download.go.cd/binaries/16.9.0-4001/rpm/go-agent-16.9.0-4001.noarch.rpm
+gocd_agent_package_name: go-agent-16.9.0-4001.noarch.rpm
 gocd_agent_package_path: /tmp
 gocd_agent_checksum: "b010587fa78ffa8fee31a53af7d58c2c3fdb7a01"
 gocd_agent_work_dir: /var/lib/go-agent

--- a/deploy/roles/gocd_server/defaults/main.yml
+++ b/deploy/roles/gocd_server/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
-gocd_server_package_url: https://download.go.cd/binaries/16.3.0-3183/rpm/go-server-16.3.0-3183.noarch.rpm
+gocd_server_package_url: https://download.go.cd/binaries/16.9.0-4001/rpm/go-server-16.9.0-4001.noarch.rpm
 gocd_server_package_path: /tmp
-gocd_server_package_name: go-server-16.3.0-3183.noarch.rpm
+gocd_server_package_name: go-server-16.9.0-4001.noarch.rpm
 gocd_server_checksum: "d7c5172b5b149d8b01c983bc8f64677779158449"
 gocd_server_work_dir: /var/lib/go-server
 gocd_server_port: 8153

--- a/deploy/roles/gocd_server/defaults/main.yml
+++ b/deploy/roles/gocd_server/defaults/main.yml
@@ -2,7 +2,7 @@
 gocd_server_package_url: https://download.go.cd/binaries/16.9.0-4001/rpm/go-server-16.9.0-4001.noarch.rpm
 gocd_server_package_path: /tmp
 gocd_server_package_name: go-server-16.9.0-4001.noarch.rpm
-gocd_server_checksum: "d7c5172b5b149d8b01c983bc8f64677779158449"
+gocd_server_checksum: "e804cc851e90144835ac715c0b41174c011f4d79"
 gocd_server_work_dir: /var/lib/go-server
 gocd_server_port: 8153
 gocd_server_ssl_port: 8154

--- a/deploy/roles/mesos_master/defaults/main.yml
+++ b/deploy/roles/mesos_master/defaults/main.yml
@@ -70,6 +70,8 @@ marathon_mesos_user: "mesagent"
 # Framework authentication credentials
 marathon_mesos_principal: "username"
 marathon_mesos_secret: "password"
+marathon_role: "marathon"
+marathon_webui_url: "https://marathon.test.dev"
 marathon_secret_file: "/etc/marathon_secret"
 
 # Artifact store

--- a/deploy/roles/mesos_master/tasks/main.yml
+++ b/deploy/roles/mesos_master/tasks/main.yml
@@ -362,6 +362,26 @@
     - mesos
     - mesos-master
 
+- name: Set Mesos role
+  copy:
+    content: "{{ marathon_role }}"
+    dest: /etc/marathon/conf/mesos_role
+  notify:
+    - restart marathon
+  tags:
+    - mesos
+    - mesos-master
+
+- name: WebUI URL
+  copy:
+    content: "{{ marathon_webui_url }}"
+    dest: /etc/marathon/conf/webui_url
+  notify:
+    - restart marathon
+  tags:
+    - mesos
+    - mesos-master
+
 ### DISABLE MESOS AGENT (INSTALLED BY RPM)
 
 # Ansible "service" command doesn't work with upstart jobs on Centos, so


### PR DESCRIPTION
We have to wait until GoCD 16.10 arrives in order to get a bug fix that prevents persistent volumes from being used with GoCD agents.
