### PR TITLE
Removes pgadmin3_96 module from deploy_development_terminal

### DIFF
--- a/deploy/deploy_development_terminal.yml
+++ b/deploy/deploy_development_terminal.yml
@@ -40,7 +40,6 @@
         - "@development"
         - gcc-gfortran
         - python-devel
-        - pgadmin3_96
 
     - name: Install custom RPMs
       yum:


### PR DESCRIPTION
pgadmin3_96 is already handled in postgresql_client role