### PR TITLE
Upgraded gocd server to match upgrade on agent from 16.10 to 16.12

### DIFF
--- a/deploy/roles/gocd_server/defaults/main.yml
+++ b/deploy/roles/gocd_server/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
-gocd_server_package_url: https://download.gocd.io/binaries/16.10.0-4131/rpm/go-server-16.10.0-4131.noarch.rpm
+gocd_server_package_url: https://download.gocd.io/binaries/16.12.0-4352/rpm/go-server-16.12.0-4352.noarch.rpm
 gocd_server_package_path: /tmp
-gocd_server_package_name: go-server-16.10.0-4131.noarch.rpm
-gocd_server_checksum: "a65e350ae8a30e86a5371b38af60874e307062d1"
+gocd_server_package_name: go-server-16.12.0-4352.noarch.rpm
+gocd_server_checksum: "4ca90c3d42a2e3492fa47f1c6316c969ad26380a"
 gocd_server_work_dir: /var/lib/go-server
 gocd_server_port: 8153
 gocd_server_ssl_port: 8154


### PR DESCRIPTION
Looks like the gocd agent was upgraded last December, but not the server, causing the server to not be able to find the agents.