### PR TITLE
Remove duplicate entries from PATH

### DIFF
--- a/deploy/roles/scala/templates/sbt.sh.j2
+++ b/deploy/roles/scala/templates/sbt.sh.j2
@@ -1,2 +1,2 @@
 export SBT_HOME=/usr/local/sbt/default
-PATH=$PATH:$SBT_HOME/bin:$PATH
+PATH=$PATH:$SBT_HOME/bin

--- a/deploy/roles/scala/templates/scala.sh.j2
+++ b/deploy/roles/scala/templates/scala.sh.j2
@@ -1,2 +1,2 @@
 export SCALA_HOME=/usr/local/scala/default
-PATH=$PATH:$SCALA_HOME/bin:$PATH
+PATH=$PATH:$SCALA_HOME/bin


### PR DESCRIPTION
I noticed that my $PATH contains 320 entries, with only 21 unique entries.

This fix remedies some of that duplication. As the path is searched from left to right, removing the duplicated elements from the end should have no effect on the order that the path is searched.