### PR TITLE
installing dependencies on citus hosts

### DIFF
--- a/deploy/deploy_citus_server.yml
+++ b/deploy/deploy_citus_server.yml
@@ -74,6 +74,7 @@
   serial: 1
   roles:
     - postgresql-server-config
+    - psql-authnz
   post_tasks:
     - name: Create Citus extension
       postgresql_exec:

--- a/deploy/roles/psql-authnz/tasks/main.yml
+++ b/deploy/roles/psql-authnz/tasks/main.yml
@@ -1,0 +1,22 @@
+- name: Install git
+  yum:
+    name: git
+    state: present
+
+- name: Install dependencies
+  yum:
+    name: "{{item}}"
+    state: present
+  with_items:
+    - virtualenv
+    - python-devel
+    - libevent-devel
+    - gcc
+    - gcc-c++
+    - kernel-devel
+    - libxslt-devel
+    - libffi-devel
+    - openssl-devel
+    - openldap-devel
+
+##ToDO: Add https://github.com/cfpb/psql-authnz deployment steps and run on citus hosts and postgres hosts


### PR DESCRIPTION
These dependencies were necessary to install on citus coordinator so that we could run the psql-authnz script